### PR TITLE
Fix nonce calculation for pending txs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Options:
           FOR TESTING ONLY: panic if a background task experiences an error for a single event
       --finalize-depth <FINALIZE_DEPTH>
           Consider blocks `finalize_depth` behind current head final. If there's a re-org deeper than this depth, the app will crash and expect to re-sync on restart [default: 64]
+      --max-pending-transactions <MAX_PENDING_TRANSACTIONS>
+          Max count of pending transactions that will be sent before waiting for inclusion of the previously sent transactions. A number higher than the max count of blobs per block should not result better UX. However, a higher number risks creating transactions that can become underpriced in volatile network conditions [default: 6]
   -h, --help
           Print help
   -V, --version

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -111,6 +111,7 @@ impl TestHarness {
             ),
             panic_on_background_task_errors: true,
             finalize_depth: FINALIZE_DEPTH,
+            max_pending_transactions: 6,
         };
 
         let app = App::build(args).await.unwrap();


### PR DESCRIPTION
Transactions can be confirmed out of order. Assigning new transactions to `head_nonce + pending_txs.len()` is not sound. 

Also, requiring to fetch the nonce on the AnchorBlock prevents syncing from old anchor blocks since the ELs do not hold that information. To unlock that, this PR drops the need to track 
This PR fetches the nonce from the EL node every time to ensure consistency.