### PR TITLE
Evict underpriced intents

### DIFF
--- a/src/block_subscriber_task.rs
+++ b/src/block_subscriber_task.rs
@@ -86,6 +86,26 @@ async fn sync_block(app_data: Arc<AppData>, block_hash: TxHash) -> Result<(), Sy
         app_data.notify.notify_one();
     }
 
+    // Check if any intents are underpriced
+    {
+        let blob_gas_price_next_block = {
+            app_data
+                .sync
+                .read()
+                .await
+                .get_head_gas()
+                .blob_gas_price_next_block()
+        };
+        let mut data_intent_tracker = app_data.data_intent_tracker.write().await;
+        let items = data_intent_tracker.get_all_pending();
+        for item in items {
+            if blob_gas_price_next_block > item.max_blob_gas_price {
+                // Underpriced transaction, evict
+                data_intent_tracker.evict_underpriced_intent(&item.id())?;
+            }
+        }
+    }
+
     // Finalize transactions
     if let Some((finalized_txs, new_anchor_block_number)) =
         app_data.sync.write().await.maybe_advance_anchor_block()?

--- a/src/data_intent_tracker.rs
+++ b/src/data_intent_tracker.rs
@@ -32,7 +32,7 @@ impl DataIntentTracker {
                         0
                     }
                 }
-                DataIntentItem::Included(_, _) => 0,
+                DataIntentItem::Evicted | DataIntentItem::Included(_, _) => 0,
             })
             .sum()
     }


### PR DESCRIPTION
After each block, if an intent has less blob gas price than the next price, mark as evicted but retain for status