### PR TITLE
Add replay protection to POST data intent

### DIFF
--- a/src/blob_tx_data.rs
+++ b/src/blob_tx_data.rs
@@ -31,14 +31,14 @@ impl BlobTxSummary {
 
     pub fn cost_to_participant(
         &self,
-        address: Address,
+        address: &Address,
         block_base_fee_per_gas: Option<u128>,
         blob_gas_price: Option<u128>,
     ) -> u128 {
         let mut cost: u128 = 0;
 
         for participant in &self.participants {
-            if participant.address == address {
+            if &participant.address == address {
                 let unused_bytes = BYTES_PER_BLOB.saturating_sub(self.used_bytes);
                 // Max product here is half blob unsued, half used by a single participant. Max
                 // blob size is 2**17, so the max intermediary value is 2**16 * 2**16 = 2**32
@@ -63,6 +63,13 @@ impl BlobTxSummary {
         } else {
             self.max_fee_per_gas
         }
+    }
+
+    pub fn participation_count_from(&self, from: &Address) -> usize {
+        self.participants
+            .iter()
+            .filter(|participant| &participant.address == from)
+            .count()
     }
 
     pub fn from_tx(tx: &Transaction) -> Result<Option<BlobTxSummary>> {
@@ -199,7 +206,7 @@ mod tests {
     fn test_cost_to_participant(address: u8, participants: &[(u8, usize)], expected_cost: usize) {
         assert_eq!(
             generate_blob_tx_summary(&participants).cost_to_participant(
-                gen_addr(address),
+                &gen_addr(address),
                 None,
                 None
             ),

--- a/src/block_subscriber_task.rs
+++ b/src/block_subscriber_task.rs
@@ -99,7 +99,7 @@ async fn sync_block(app_data: Arc<AppData>, block_hash: TxHash) -> Result<(), Sy
         let mut data_intent_tracker = app_data.data_intent_tracker.write().await;
         let items = data_intent_tracker.get_all_pending();
         for item in items {
-            if blob_gas_price_next_block > item.max_blob_gas_price {
+            if item.max_blob_gas_price() < blob_gas_price_next_block {
                 // Underpriced transaction, evict
                 data_intent_tracker.evict_underpriced_intent(&item.id())?;
             }

--- a/src/client.rs
+++ b/src/client.rs
@@ -32,6 +32,7 @@ impl Client {
         wallet: &LocalWallet,
         data: Vec<u8>,
         gas: &GasPreference,
+        nonce: &NoncePreference,
     ) -> Result<PostDataResponse> {
         // TODO: customize, for now set gas price equal to next block
         // TODO: Close to genesis block the value is 1, which requires blobs to be perfectly full
@@ -39,7 +40,10 @@ impl Client {
 
         // TODO: Consider exposing different nonce options.
         // TODO: Is it safe to query to nonce from the server?
-        let nonce = self.get_nonce_by_address(wallet.address()).await?;
+        let nonce = match nonce {
+            NoncePreference::FetchFromApi => self.get_nonce_by_address(wallet.address()).await?,
+            NoncePreference::Value(nonce) => *nonce,
+        };
 
         let intent_signed = PostDataIntentV1Signed::with_signature(
             wallet,
@@ -159,4 +163,9 @@ impl GasPreference {
             }
         }
     }
+}
+
+pub enum NoncePreference {
+    FetchFromApi,
+    Value(u64),
 }

--- a/src/data_intent_tracker.rs
+++ b/src/data_intent_tracker.rs
@@ -21,12 +21,13 @@ pub enum DataIntentItem {
 
 // TODO: Need to prune all items once included for long enough
 impl DataIntentTracker {
-    pub fn pending_intents_total_cost(&self, from: Address) -> u128 {
+    /// Returns the total sum of pending itents cost from `from`.
+    pub fn pending_intents_total_cost(&self, from: &Address) -> u128 {
         self.pending_intents
             .values()
             .map(|item| match item {
                 DataIntentItem::Pending(data_intent) => {
-                    if data_intent.from == from {
+                    if data_intent.from() == from {
                         data_intent.max_cost()
                     } else {
                         0
@@ -35,6 +36,23 @@ impl DataIntentTracker {
                 DataIntentItem::Evicted | DataIntentItem::Included(_, _) => 0,
             })
             .sum()
+    }
+
+    /// Returns the max nonce out of all pending intents
+    pub fn pending_nonces(&self, from: &Address) -> Vec<u64> {
+        self.pending_intents
+            .values()
+            .filter_map(|item| match item {
+                DataIntentItem::Pending(data_intent) => {
+                    if data_intent.from() == from {
+                        Some(data_intent.nonce())
+                    } else {
+                        None
+                    }
+                }
+                DataIntentItem::Evicted | DataIntentItem::Included(_, _) => None,
+            })
+            .collect()
     }
 
     pub fn get_all_pending(&self) -> Vec<DataIntent> {

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -51,14 +51,15 @@ pub(crate) fn construct_blob_tx(
     let participants = next_blob_items
         .iter()
         .map(|item| BlobTxParticipant {
-            address: item.from,
-            data_len: item.data.len(),
+            address: *item.from(),
+            data_len: item.data().len(),
         })
         .collect::<Vec<_>>();
 
     let mut data = vec![];
-    for mut item in next_blob_items.into_iter() {
-        data.append(&mut item.data);
+    for item in next_blob_items.into_iter() {
+        // TODO: do less copying
+        data.extend_from_slice(item.data());
     }
 
     // TODO: should chunk data in 31 bytes to ensure each field element if < BLS_MODULUS
@@ -224,12 +225,12 @@ mod tests {
         for i in 0..2 {
             let wallet = LocalWallet::from_bytes(&[i + 1; 32])?;
             data_intents.push(
-                DataIntent::with_signature(&wallet, vec![i + 0x10; 1000 * i as usize], 1)
+                DataIntent::with_signature(&wallet, vec![i + 0x10; 1000 * i as usize], 0, 1)
                     .await
                     .unwrap(),
             );
         }
-        let participants = data_intents.iter().map(|p| p.from).collect::<Vec<_>>();
+        let participants = data_intents.iter().map(|p| *p.from()).collect::<Vec<_>>();
 
         let blob_tx = construct_blob_tx(
             &load_kzg_settings()?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,8 @@ use crate::{
     blob_sender_task::blob_sender_task,
     block_subscriber_task::block_subscriber_task,
     routes::{
-        get_balance_by_address, get_data, get_data_by_id, get_health, get_home, get_sender,
-        get_status_by_id, get_sync, post_data,
+        get_balance_by_address, get_data, get_data_by_id, get_health, get_home,
+        get_nonce_by_address, get_sender, get_status_by_id, get_sync, post_data::post_data,
     },
     sync::{AnchorBlock, BlockSync, BlockSyncConfig},
     trusted_setup::TrustedSetup,
@@ -194,6 +194,7 @@ impl App {
                     gas: BlockGasSummary::from_block(&anchor_block)?,
                     // At genesis all balances are zero
                     finalized_balances: <_>::default(),
+                    finalized_user_participation_count: <_>::default(),
                 }
             }
         };
@@ -247,6 +248,7 @@ impl App {
                 .service(get_data_by_id)
                 .service(get_status_by_id)
                 .service(get_balance_by_address)
+                .service(get_nonce_by_address)
         })
         .listen(listener)?
         .run();

--- a/src/routes/post_data.rs
+++ b/src/routes/post_data.rs
@@ -78,7 +78,7 @@ pub struct PostDataIntentV1 {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PostDataIntentV1Signed {
     pub intent: PostDataIntentV1,
-    /// Signature over [data,nonce,max_blob_gas_price]
+    /// Signature over := data | nonce | max_blob_gas_price
     #[serde(with = "hex_vec")]
     pub signature: Vec<u8>,
 }

--- a/src/routes/post_data.rs
+++ b/src/routes/post_data.rs
@@ -1,0 +1,249 @@
+use actix_web::{post, web, HttpResponse};
+use ethers::signers::{LocalWallet, Signer};
+use ethers::types::{Address, Signature};
+use eyre::{bail, eyre, Result};
+use serde::{Deserialize, Serialize};
+use serde_utils::hex_vec;
+use std::sync::Arc;
+
+use crate::data_intent::{DataHash, DataIntent, DataIntentNoSignature};
+use crate::utils::{deserialize_signature, e400, e500};
+use crate::AppData;
+
+#[post("/v1/data")]
+pub(crate) async fn post_data(
+    body: web::Json<PostDataIntentV1Signed>,
+    data: web::Data<Arc<AppData>>,
+) -> Result<HttpResponse, actix_web::Error> {
+    // .try_into() verifies the signature
+    let data_intent: DataIntent = body.into_inner().try_into().map_err(e400)?;
+
+    // Check that the nonce is the next expected
+    let expected_next_nonce = data.nonce_of_user(data_intent.from()).await;
+    if expected_next_nonce != data_intent.nonce() {
+        return Err(e400(eyre!(
+            "incorrect nonce {} expected {}",
+            data_intent.nonce(),
+            expected_next_nonce
+        )));
+    }
+
+    // Check user has enough balance to cover the max cost allowed
+    let balance = data.balance_of_user(data_intent.from()).await;
+    if balance < data_intent.max_cost() as i128 {
+        return Err(e400(eyre!(
+            "Insufficient balance, current balance {} requested {}",
+            balance,
+            data_intent.max_cost()
+        )));
+    }
+
+    // data_intent_tracker ensures no duplicates at this point, everything before this statement
+    // must be immmutable checks
+    let id = data_intent.id();
+    data.data_intent_tracker
+        .write()
+        .await
+        .add(data_intent)
+        .map_err(e500)?;
+
+    // Potentially send a blob transaction including this new participation
+    data.notify.notify_one();
+
+    Ok(HttpResponse::Ok().json(PostDataResponse { id: id.to_string() }))
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PostDataResponse {
+    pub id: String,
+}
+
+/// TODO: Expose a "login with Ethereum" function an expose the non-signed variant
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PostDataIntentV1 {
+    /// Address sending the data
+    pub from: Address,
+    /// Data to be posted
+    #[serde(with = "hex_vec")]
+    pub data: Vec<u8>,
+    /// DataIntent nonce, to allow replay protection. Each new intent must have a nonce higher than
+    /// the last known nonce from this `from` sender. Re-pricings will be done with a different
+    /// nonce
+    pub nonce: u64,
+    /// Max price user is willing to pay in wei
+    pub max_blob_gas_price: u128,
+}
+
+/// PostDataIntent message for non authenticated channels
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PostDataIntentV1Signed {
+    pub intent: PostDataIntentV1,
+    /// Signature over [data,nonce,max_blob_gas_price]
+    #[serde(with = "hex_vec")]
+    pub signature: Vec<u8>,
+}
+
+impl PostDataIntentV1Signed {
+    pub async fn with_signature(wallet: &LocalWallet, intent: PostDataIntentV1) -> Result<Self> {
+        if wallet.address() != intent.from {
+            bail!(
+                "intent.from {} does not match wallet address {}",
+                intent.from,
+                wallet.address()
+            );
+        }
+
+        let signature: Signature = wallet.sign_message(Self::sign_hash(&intent)).await?;
+
+        Ok(Self {
+            intent,
+            signature: signature.into(),
+        })
+    }
+
+    fn sign_hash(intent: &PostDataIntentV1) -> Vec<u8> {
+        let data_hash = DataHash::from_data(&intent.data);
+
+        // Concat: data_hash | nonce | max_blob_gas_price
+        let mut signed_data = data_hash.to_vec();
+        signed_data.extend_from_slice(&intent.nonce.to_be_bytes());
+        signed_data.extend_from_slice(&intent.max_blob_gas_price.to_be_bytes());
+
+        signed_data
+    }
+
+    fn verify_signature(&self) -> Result<()> {
+        let signature = deserialize_signature(&self.signature)?;
+        let sign_hash = PostDataIntentV1Signed::sign_hash(&self.intent);
+        signature.verify(sign_hash, self.intent.from)?;
+        Ok(())
+    }
+}
+
+impl TryInto<DataIntent> for PostDataIntentV1Signed {
+    type Error = eyre::Report;
+
+    fn try_into(self) -> Result<DataIntent, Self::Error> {
+        self.verify_signature()?;
+
+        Ok(self.intent.into())
+    }
+}
+
+impl From<PostDataIntentV1> for DataIntent {
+    fn from(val: PostDataIntentV1) -> Self {
+        let data_hash = DataHash::from_data(&val.data);
+        Self::NoSignature(DataIntentNoSignature {
+            from: val.from,
+            data: val.data,
+            data_hash,
+            nonce: val.nonce,
+            max_blob_gas_price: val.max_blob_gas_price,
+        })
+    }
+}
+
+impl From<DataIntent> for PostDataIntentV1 {
+    fn from(value: DataIntent) -> Self {
+        match value {
+            DataIntent::NoSignature(d) => Self {
+                from: d.from,
+                data: d.data,
+                nonce: d.nonce,
+                max_blob_gas_price: d.max_blob_gas_price,
+            },
+            DataIntent::WithSignature(d) => Self {
+                from: d.from,
+                data: d.data,
+                nonce: d.nonce,
+                max_blob_gas_price: d.max_blob_gas_price,
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use ethers::signers::{LocalWallet, Signer};
+    use ethers::types::Address;
+    use eyre::Result;
+    use std::str::FromStr;
+
+    use super::*;
+
+    #[test]
+    fn route_post_data_intent_v1_serde() -> Result<()> {
+        let data_intent = PostDataIntentV1 {
+            from: Address::from_str("0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045")?,
+            data: vec![0xaa; 50],
+            nonce: 123,
+            max_blob_gas_price: 1000000000,
+        };
+
+        assert_eq!(&serde_json::to_string(&data_intent)?, "{\"from\":\"0xd8da6bf26964af9d7eed9e03e53415d37aa96045\",\"data\":\"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\",\"nonce\":123,\"max_blob_gas_price\":1000000000}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn data_intent_signature_valid() -> Result<()> {
+        let data = vec![0xaa; 50];
+        let wallet = get_wallet()?;
+        let intent = PostDataIntentV1 {
+            from: wallet.address(),
+            data,
+            nonce: 0,
+            max_blob_gas_price: 1000,
+        };
+        let post_data_intent_signed =
+            PostDataIntentV1Signed::with_signature(&&wallet, intent).await?;
+
+        post_data_intent_signed.verify_signature()?;
+
+        let _recovered_intent: DataIntent = post_data_intent_signed.try_into()?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn data_intent_signature_invalid() -> Result<()> {
+        let data = vec![0xaa; 50];
+        let wallet = get_wallet()?;
+        let intent = PostDataIntentV1 {
+            from: wallet.address(),
+            data,
+            nonce: 0,
+            max_blob_gas_price: 1000,
+        };
+        let mut post_data_intent_signed =
+            PostDataIntentV1Signed::with_signature(&&wallet, intent).await?;
+        post_data_intent_signed.intent.from = [0; 20].into();
+
+        assert_eq!(
+            post_data_intent_signed
+                .verify_signature()
+                .unwrap_err()
+                .to_string(),
+            "Signature verification failed. Expected 0x0000…0000, got 0xdbd4…3277"
+        );
+
+        assert_eq!(
+            TryInto::<DataIntent>::try_into(post_data_intent_signed)
+                .unwrap_err()
+                .to_string(),
+            "Signature verification failed. Expected 0x0000…0000, got 0xdbd4…3277"
+        );
+
+        Ok(())
+    }
+
+    const DEV_PRIVKEY: &str = "392a230386a19b84b6b865067d5493b158e987d28104ab16365854a8fd851bb0";
+    const DEV_PUBKEY: &str = "0xdbD48e742FF3Ecd3Cb2D557956f541b6669b3277";
+
+    pub fn get_wallet() -> Result<LocalWallet> {
+        let wallet = LocalWallet::from_bytes(&hex::decode(DEV_PRIVKEY)?)?;
+        assert_eq!(wallet.address(), Address::from_str(DEV_PUBKEY)?);
+        Ok(wallet)
+    }
+}

--- a/src/sender/main.rs
+++ b/src/sender/main.rs
@@ -2,7 +2,9 @@ use std::fs;
 use std::str::FromStr;
 use std::time::Duration;
 
-use blob_share::client::{Client, DataIntentId, DataIntentStatus, EthProvider, GasPreference};
+use blob_share::client::{
+    Client, DataIntentId, DataIntentStatus, EthProvider, GasPreference, NoncePreference,
+};
 use clap::Parser;
 use ethers::middleware::SignerMiddleware;
 use ethers::providers::{Http, Middleware, Provider};
@@ -125,8 +127,11 @@ async fn main() -> Result<()> {
 
     let gas =
         GasPreference::RelativeToHead(EthProvider::Http(provider), args.blob_gas_price_factor);
+    let nonce = NoncePreference::FetchFromApi;
 
-    let response = client.post_data_with_wallet(&wallet, data, &gas).await?;
+    let response = client
+        .post_data_with_wallet(&wallet, data, &gas, &nonce)
+        .await?;
     let id = DataIntentId::from_str(&response.id)?;
     println!("{:?}", id);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-use ethers::types::Address;
+use ethers::types::{Address, Signature};
 use eyre::{bail, Result};
 use reqwest::Response;
 use std::cmp::PartialEq;
@@ -54,4 +54,9 @@ pub async fn is_ok_response(response: Response) -> Result<Response> {
 /// Return 0x prefixed hex representation of address (not checksum)
 pub fn address_to_hex(addr: Address) -> String {
     format!("0x{}", hex::encode(addr.to_fixed_bytes()))
+}
+
+/// Deserialize ethers' Signature
+pub fn deserialize_signature(signature: &[u8]) -> Result<Signature> {
+    Ok(signature.try_into()?)
 }

--- a/tests/api/post_intents.rs
+++ b/tests/api/post_intents.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use crate::helpers::{retry_with_timeout, unique, TestHarness, TestMode, FINALIZE_DEPTH};
-use blob_share::MAX_USABLE_BLOB_DATA_LEN;
+use blob_share::{client::NoncePreference, MAX_USABLE_BLOB_DATA_LEN};
 use ethers::signers::{LocalWallet, Signer};
 use futures::future::join_all;
 
@@ -204,14 +204,20 @@ async fn post_many_intents_parallel_and_expect_blob_tx() {
                     .map(|i| vec![0xa0_u8 + i; MAX_USABLE_BLOB_DATA_LEN / 2])
                     .collect::<Vec<_>>();
 
-                // Post all datas at once
-                let intent_ids = join_all(
-                    datas
-                        .iter()
-                        .map(|data| test_harness.post_data(&wallet.signer(), data.to_vec()))
-                        .collect::<Vec<_>>(),
-                )
-                .await;
+                // Post all datas in quick succession before asserting for inclusion. Post in
+                // sequence so the server can check the nonce is sequential.
+                let mut intent_ids = vec![];
+                for (i, data) in datas.iter().enumerate() {
+                    intent_ids.push(
+                        test_harness
+                            .post_data(
+                                &wallet.signer(),
+                                data.to_vec(),
+                                Some(NoncePreference::Value(i as u64)),
+                            )
+                            .await,
+                    )
+                }
 
                 // All intents should be known immediatelly
                 test_harness

--- a/tests/api/post_intents.rs
+++ b/tests/api/post_intents.rs
@@ -105,7 +105,7 @@ async fn test_post_two_data_intents_up_to_inclusion(
         .get_data_by_id(&intent_1_id)
         .await
         .unwrap();
-    assert_eq!(intent_1.data, data_1);
+    assert_eq!(intent_1.data(), data_1);
 
     // Check balance has decreased
     let balance_after_intent_1 = test_harness


### PR DESCRIPTION
Track data intent / participations nonce and enforce payloads sent to the unprotected endpoint POST /v1/data to sign over the nonce.