### PR TITLE
Replace log with tracing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 invalid_tx_blob_*.rlp
 .env
+/data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
  "url",
 ]
@@ -2732,6 +2733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3583,8 +3593,17 @@ checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.3",
  "regex-syntax 0.8.2",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3597,6 +3616,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.2",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4890,10 +4915,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ bytes = "1.5.0"
 alloy-rlp = "0.3.3"
 async-trait = "0.1.74"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 reqwest = "0.11.22"
 ethereum_serde_utils = "0.5"
 url = "2.5.0"
@@ -60,6 +60,7 @@ rand = "0.8.5"
 prometheus = { version = "0.13.3", features = ["push"] }
 lazy_static = "1.4.0"
 dotenv = "0.15.0"
+tracing-log = "0.2.0"
 
 [dev-dependencies]
 hex = "0.4.3"

--- a/src/block_subscriber_task.rs
+++ b/src/block_subscriber_task.rs
@@ -43,9 +43,7 @@ pub(crate) async fn block_subscriber_task(app_data: Arc<AppData>) -> Result<()> 
                             error!("error syncing block {:?}: {:?}", block_hash, e);
                         }
                     }
-                    Ok(_) => {
-                        debug!("completed sync_block task for {block_hash}");
-                    }
+                    Ok(_) => {}
                 }
 
                 // Maybe compute new blob transactions
@@ -59,6 +57,7 @@ pub(crate) async fn block_subscriber_task(app_data: Arc<AppData>) -> Result<()> 
     Ok(())
 }
 
+#[tracing::instrument(ret, err, skip(app_data), fields(block_hash = %block_hash))]
 async fn sync_block(app_data: Arc<AppData>, block_hash: TxHash) -> Result<(), SyncBlockError> {
     let _timer = metrics::BLOCK_SUBSCRIBER_TASK_TIMES.start_timer();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub use utils::increase_by_min_percent;
 
 // Use log crate when building application
 #[cfg(not(test))]
-pub(crate) use log::{debug, error, info, warn};
+pub(crate) use tracing::{debug, error, info, warn};
 
 // Workaround to use prinltn! for logs.
 // std stdio has dedicated logic to capture logs during test execution

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,29 @@ use blob_share::{App, Args};
 use clap::Parser;
 use dotenv::dotenv;
 use eyre::Result;
+use tracing_log::LogTracer;
+use tracing_subscriber::{self, EnvFilter, FmtSubscriber};
 
 #[actix_web::main]
 async fn main() -> Result<()> {
     dotenv().ok();
-    env_logger::init_from_env(env_logger::Env::new().default_filter_or("info,blob_share=debug"));
+
+    LogTracer::init()?;
+
+    // A simple logger that outputs to stdout
+    let subscriber = FmtSubscriber::builder()
+        .with_env_filter(EnvFilter::from_default_env())
+        // .compact()
+        // .with_file(true)
+        // .with_line_number(true)
+        // .with_thread_ids(true)
+        // .with_target(true)
+        .finish();
+
+    // Set the subscriber as the global default
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
+
+    // env_logger::init_from_env(env_logger::Env::new().default_filter_or("info,blob_share=debug"));
 
     let args = Args::parse();
     let app = App::build(args).await?;

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -107,6 +107,7 @@ pub(crate) async fn get_status_by_id(
     Ok(HttpResponse::Ok().json(status))
 }
 
+#[tracing::instrument(skip(data))]
 #[get("/v1/balance/{address}")]
 pub(crate) async fn get_balance_by_address(
     data: web::Data<Arc<AppData>>,
@@ -116,6 +117,7 @@ pub(crate) async fn get_balance_by_address(
     Ok(HttpResponse::Ok().json(balance))
 }
 
+#[tracing::instrument(skip(data))]
 #[get("/v1/last_seen_nonce/{address}")]
 pub(crate) async fn get_last_seen_nonce_by_address(
     data: web::Data<Arc<AppData>>,
@@ -212,6 +214,7 @@ async fn get_node_head(provider: &EthProvider) -> Result<SyncStatusBlock> {
 }
 
 impl AppData {
+    #[tracing::instrument(skip(self))]
     async fn balance_of_user(&self, from: &Address) -> i128 {
         self.sync.read().await.balance_with_pending(from)
             - self

--- a/src/routes/post_data.rs
+++ b/src/routes/post_data.rs
@@ -11,6 +11,7 @@ use crate::data_intent::{DataHash, DataIntent, DataIntentNoSignature};
 use crate::utils::{deserialize_signature, e400, e500, unix_timestamps_millis};
 use crate::AppData;
 
+#[tracing::instrument(skip(body, data))]
 #[post("/v1/data")]
 pub(crate) async fn post_data(
     body: web::Json<PostDataIntentV1Signed>,


### PR DESCRIPTION
Why instrument:
- Easier to context logs with attached metadata
- Succint way to request logs based on return value, error

Goals besides regular instrument:
- On testing capture logs with cargo test sink
- Display actix_web info status logs