### PR TITLE
Revert 401 temp patch and collect metrics

### DIFF
--- a/src/data_intent_tracker.rs
+++ b/src/data_intent_tracker.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use ethers::types::{Address, TxHash};
 use eyre::{bail, eyre, Result};
 
-use crate::{data_intent::DataIntentId, DataIntent};
+use crate::{data_intent::DataIntentId, metrics, DataIntent};
 
 #[derive(Default)]
 pub struct DataIntentTracker {
@@ -21,6 +21,11 @@ pub enum DataIntentItem {
 
 // TODO: Need to prune all items once included for long enough
 impl DataIntentTracker {
+    pub fn collect_metrics(&self) {
+        metrics::PENDING_INTENTS_CACHE.set(self.pending_intents.len() as f64);
+        metrics::INCLUDED_INTENTS_CACHE.set(self.included_intents.len() as f64);
+    }
+
     /// Returns the total sum of pending itents cost from `from`.
     pub fn pending_intents_total_cost(&self, from: &Address) -> u128 {
         self.pending_intents

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,6 +177,13 @@ struct AppData {
     config: AppConfig,
 }
 
+impl AppData {
+    async fn collect_metrics(&self) {
+        self.sync.read().await.collect_metrics();
+        self.data_intent_tracker.read().await.collect_metrics();
+    }
+}
+
 pub struct App {
     port: u16,
     server: Server,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::RwLock;
 
 use crate::{
-    blob_tx_data::BlobTxSummary, debug, eth_provider::EthProvider, info, routes::SyncStatusBlock,
-    BlockGasSummary,
+    blob_tx_data::BlobTxSummary, debug, eth_provider::EthProvider, info, metrics,
+    routes::SyncStatusBlock, BlockGasSummary,
 };
 
 type Nonce = u64;
@@ -74,6 +74,11 @@ impl BlockSync {
             pending_transactions: <_>::default(),
             config,
         }
+    }
+
+    pub fn collect_metrics(&self) {
+        metrics::SYNC_HEAD_NUMBER.set(self.get_head().number as f64);
+        metrics::SYNC_ANCHOR_NUMBER.set(self.get_anchor().number as f64);
     }
 
     /// Return gas summary of the current head


### PR DESCRIPTION
Grafana Cloud setup successfully, it just needed a 401 response when passing no token, then a 200 when passing the token.