### PR TITLE
Handle transaction re-pricing and multiple inclusion

### DIFF
--- a/.sqlx/query-42ac4b902bad22b6226cf2b08958db505d36fc6deb025f176fc37aba4df57efe.json
+++ b/.sqlx/query-42ac4b902bad22b6226cf2b08958db505d36fc6deb025f176fc37aba4df57efe.json
@@ -1,0 +1,58 @@
+{
+  "db_name": "MySQL",
+  "query": "\nSELECT id, tx_hash, sender_address, nonce\nFROM intent_inclusions\nWHERE id = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 16
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "tx_hash",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 32
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "sender_address",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 20
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "nonce",
+        "type_info": {
+          "type": "Long",
+          "flags": "NOT_NULL | MULTIPLE_KEY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 11
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "42ac4b902bad22b6226cf2b08958db505d36fc6deb025f176fc37aba4df57efe"
+}

--- a/.sqlx/query-a6ccf35f6bd2d265828b86c39a1e5a5a2674554f7b2256832ea4a8b9e7fe5d72.json
+++ b/.sqlx/query-a6ccf35f6bd2d265828b86c39a1e5a5a2674554f7b2256832ea4a8b9e7fe5d72.json
@@ -1,6 +1,6 @@
 {
   "db_name": "MySQL",
-  "query": "\nSELECT id, tx_hash, sender_address, nonce\nFROM intent_inclusions\nWHERE id = ?\n        ",
+  "query": "\nSELECT id, tx_hash, sender_address, nonce, updated_at\nFROM intent_inclusions\nWHERE id = ?\nORDER BY nonce ASC, updated_at ASC\n        ",
   "describe": {
     "columns": [
       {
@@ -42,6 +42,16 @@
           "char_set": 63,
           "max_size": 11
         }
+      },
+      {
+        "ordinal": 4,
+        "name": "updated_at",
+        "type_info": {
+          "type": "Timestamp",
+          "flags": "BINARY | TIMESTAMP | ON_UPDATE_NOW",
+          "char_set": 63,
+          "max_size": 23
+        }
       }
     ],
     "parameters": {
@@ -51,8 +61,9 @@
       false,
       false,
       false,
-      false
+      false,
+      true
     ]
   },
-  "hash": "42ac4b902bad22b6226cf2b08958db505d36fc6deb025f176fc37aba4df57efe"
+  "hash": "a6ccf35f6bd2d265828b86c39a1e5a5a2674554f7b2256832ea4a8b9e7fe5d72"
 }

--- a/.sqlx/query-cee4100ac96df98989003c4c6815ab6a2ba4353fffad9aef8041f12f3dcd05f4.json
+++ b/.sqlx/query-cee4100ac96df98989003c4c6815ab6a2ba4353fffad9aef8041f12f3dcd05f4.json
@@ -1,0 +1,25 @@
+{
+  "db_name": "MySQL",
+  "query": "\nSELECT id \nFROM data_intents\nWHERE id = ?\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 16
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "cee4100ac96df98989003c4c6815ab6a2ba4353fffad9aef8041f12f3dcd05f4"
+}

--- a/.sqlx/query-f65e441cbfac899e816a4ede485992496ca160fe37254bfe24476b5b3c77d821.json
+++ b/.sqlx/query-f65e441cbfac899e816a4ede485992496ca160fe37254bfe24476b5b3c77d821.json
@@ -1,0 +1,36 @@
+{
+  "db_name": "MySQL",
+  "query": "\nSELECT data_intents.id, intent_inclusions.tx_hash\nFROM data_intents\nINNER JOIN intent_inclusions ON data_intents.id = intent_inclusions.id\nWHERE data_intents.inclusion_finalized = FALSE;\n",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 16
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "tx_hash",
+        "type_info": {
+          "type": "String",
+          "flags": "NOT_NULL | PRIMARY_KEY | MULTIPLE_KEY | BINARY | NO_DEFAULT_VALUE",
+          "char_set": 63,
+          "max_size": 32
+        }
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false
+    ]
+  },
+  "hash": "f65e441cbfac899e816a4ede485992496ca160fe37254bfe24476b5b3c77d821"
+}

--- a/migrations/20231223063356_create_data_intent_table.sql
+++ b/migrations/20231223063356_create_data_intent_table.sql
@@ -2,10 +2,25 @@
 -- - User may submit the same data twice
 -- - Economically bounded, only accepts data intents that the user can afford
 -- - Never pruned, data intents remain in the DB forever after finalization
+--
+-- # Queries
+-- * For packing retrieve intents available for inclusion (non included + underpriced)
+--   > Select all rows WHERE inclusion_finalized == false
+-- * Intent explorer, return intent details by id
+-- 
+-- # Pruning
+-- Never prunes
+--
+-- # Mutation
+-- Set `inclusion_finalized = true` after finalizing inclusion. This value is an optimization,
+-- and can be updated at any latter point. An consumer should do a consistency check on startup
+-- to potentially set inclusion_finalized to true if: there's a an inclusion, for a known tx, in
+-- a block with number < anchor block.
+-- 
 CREATE TABLE data_intents (
     id BINARY(16) PRIMARY KEY, -- UUID as binary
     -- sender address
-    eth_address BINARY(20),
+    eth_address BINARY(20) NOT NULL,
     -- binary data to publish, MEDIUMBLOB = binary large object with max length of 2^24-1 bytes (16MB)
     data MEDIUMBLOB NOT NULL,
     -- byte length of data, max possible size is 131,072 < INT::MAX = 2,147,483,647
@@ -16,12 +31,13 @@ CREATE TABLE data_intents (
     max_blob_gas_price BIGINT UNSIGNED NOT NULL,
     -- Optional ECDSA signature over data_hash, serialized
     data_hash_signature BINARY(65) DEFAULT NULL,
-    -- Transaction hash of the included 
-    inclusion_tx_hash BINARY(32) DEFAULT NULL,
+    -- Inclusion finalized
+    inclusion_finalized BOOL DEFAULT false,
     -- Timestamp with milisecond level precision, automatically populated
     updated_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
     -- Index created_at to query recently added intents efficiently. The query:
     -- `EXPLAIN ANALYZE SELECT * FROM data_intents WHERE updated_at > '2024-01-01 00:00:00';`
     -- against PlanetScale consumes 0 row read credits if there are no matches.
-    INDEX(updated_at)
+    INDEX(updated_at),
+    INDEX(inclusion_finalized)
 );

--- a/migrations/20240101133133_create_intent_inclusion_table.sql
+++ b/migrations/20240101133133_create_intent_inclusion_table.sql
@@ -1,0 +1,33 @@
+-- # Queries 
+-- * List of intent IDs that can be included in a new bundle (no inclusion + underpriced inclusion)
+--   > Query all rows with nonce > finalized nonce for sender address
+-- * For a specific historic intent ID, retrieve which transaction and block is included into efficiently
+--   > Query rows WHERE id = ? and pick the most recent or canonical
+-- * Prune inclusions for dropped transactions
+--   > Remove rows WHERE tx_hash = ?
+--
+-- # Pruning
+-- Prunes non canonical re-priced transactions 
+--
+-- # Mutation
+-- None
+-- 
+CREATE TABLE intent_inclusions (
+    -- data intent UUID as binary
+    id BINARY(16) NOT NULL,
+    -- Transaction hash that includes this set of IDs
+    tx_hash BINARY(32) NOT NULL,
+    -- Tx from
+    sender_address BINARY(20) NOT NULL,
+    -- Tx nonce from sender
+    nonce INT NOT NULL,
+    -- Timestamp with milisecond level precision, automatically populated
+    updated_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+
+    PRIMARY KEY(id, tx_hash),
+    -- Allow to query inclusions by data intent ID or transaction hash
+    INDEX(id),
+    INDEX(tx_hash),
+    INDEX(sender_address),
+    INDEX(nonce)
+);

--- a/src/blob_sender_task.rs
+++ b/src/blob_sender_task.rs
@@ -103,8 +103,13 @@ pub(crate) async fn maybe_send_blob_tx(app_data: Arc<AppData>, _id: u64) -> Resu
     let data_intents = app_data.data_intents_by_id(&data_intent_ids).await?;
 
     // TODO: Check if it's necessary to do a round-trip to the EL to estimate gas
+    //
+    // ### EIP-1559 refresher:
+    // - assert tx.max_fee_per_gas >= tx.max_priority_fee_per_gas
+    // - priority_fee_per_gas = min(tx.max_priority_fee_per_gas, tx.max_fee_per_gas - block.base_fee_per_gas)
     let (max_fee_per_gas, max_priority_fee_per_gas) =
         app_data.provider.estimate_eip1559_fees().await?;
+
     let gas_config = GasConfig {
         max_fee_per_gas: max_fee_per_gas.as_u128(),
         max_priority_fee_per_gas: max_priority_fee_per_gas.as_u128(),

--- a/src/blob_tx_data.rs
+++ b/src/blob_tx_data.rs
@@ -126,12 +126,6 @@ impl BlobTxSummary {
     }
 }
 
-impl Into<GasConfig> for &BlobTxSummary {
-    fn into(self) -> GasConfig {
-        self.gas
-    }
-}
-
 const PARTICIPANT_VERSION_1: u8 = 0x01;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -204,9 +198,11 @@ mod tests {
             from: Address::default(),
             nonce: 0,
             used_bytes: participants.iter().map(|(_, data_len)| data_len).sum(),
-            max_priority_fee_per_gas: 1,
-            max_fee_per_gas: 1,
-            max_fee_per_blob_gas: 1,
+            gas: GasConfig {
+                max_priority_fee_per_gas: 1,
+                max_fee_per_gas: 1,
+                max_fee_per_blob_gas: 1,
+            },
         }
     }
 
@@ -216,11 +212,7 @@ mod tests {
 
     fn test_cost_to_participant(address: u8, participants: &[(u8, usize)], expected_cost: usize) {
         assert_eq!(
-            generate_blob_tx_summary(&participants).cost_to_participant(
-                &gen_addr(address),
-                None,
-                None
-            ),
+            generate_blob_tx_summary(&participants).cost_to_participant(&gen_addr(address), None,),
             expected_cost as u128
         );
     }
@@ -304,9 +296,11 @@ mod tests {
             from: target_address,
             nonce,
             used_bytes,
-            max_fee_per_gas: 1,
-            max_priority_fee_per_gas: 2,
-            max_fee_per_blob_gas: 3,
+            gas: GasConfig {
+                max_fee_per_gas: 1,
+                max_priority_fee_per_gas: 2,
+                max_fee_per_blob_gas: 3,
+            },
         };
 
         assert_eq!(blob_tx_summary, expected_blob_tx_summary);

--- a/src/blob_tx_data.rs
+++ b/src/blob_tx_data.rs
@@ -1,10 +1,10 @@
 use std::io::{Cursor, Read, Write};
 
 use c_kzg::BYTES_PER_BLOB;
-use ethers::types::{Address, Transaction, H256, U256};
+use ethers::types::{Address, Transaction, H256};
 use eyre::{bail, eyre, Context, Result};
 
-use crate::BlockGasSummary;
+use crate::{utils::get_max_fee_per_blob_gas, BlockGasSummary};
 
 pub const BLOB_TX_TYPE: u8 = 0x03;
 const PARTICIPANT_DATA_SIZE: usize = 20 + 4;
@@ -101,11 +101,7 @@ impl BlobTxSummary {
             .max_priority_fee_per_gas
             .ok_or_else(|| eyre!("not a type 2 tx, no max_priority_fee_per_gas"))?
             .as_u128();
-        let max_fee_per_blob_gas: U256 = tx
-            .other
-            .get_deserialized("maxFeePerBlobGas")
-            .ok_or_else(|| eyre!("not a type 3 tx, no max_fee_per_blob_gas"))??;
-        let max_fee_per_blob_gas = max_fee_per_blob_gas.as_u128();
+        let max_fee_per_blob_gas = get_max_fee_per_blob_gas(tx)?;
 
         let used_bytes = participants.iter().map(|p| p.data_len).sum::<usize>();
 

--- a/src/block_subscriber_task.rs
+++ b/src/block_subscriber_task.rs
@@ -22,6 +22,7 @@ pub(crate) async fn block_subscriber_task(app_data: Arc<AppData>) -> Result<()> 
     loop {
         tokio::select! {
             block_hash = s.next() => {
+                // block_hash type := Option<Result<H256>>
                 let block_hash = block_hash.ok_or_else(|| eyre!("block stream closed"))??;
 
                 // Run sync routine, may involve long network requests if there's a re-org

--- a/src/block_subscriber_task.rs
+++ b/src/block_subscriber_task.rs
@@ -99,13 +99,8 @@ async fn sync_block(app_data: Arc<AppData>, block_hash: TxHash) -> Result<(), Sy
         block_number, block_hash, outcome
     );
 
-    // Check if any pending transactions need re-pricing
-    let underpriced_txs = app_data.evict_underpriced_pending_txs().await?;
-    if underpriced_txs > 0 {
-        metrics::UNDERPRICED_TXS_EVICTED.inc_by(underpriced_txs as f64);
-        // Potentially prepare new blob transactions with correct pricing
-        app_data.notify.notify_one();
-    }
+    // Always attempt to re-bundle after syncing a block
+    app_data.notify.notify_one();
 
     // Finalize transactions
     if let Some((finalized_txs, new_anchor_block_number)) =

--- a/src/client.rs
+++ b/src/client.rs
@@ -133,6 +133,15 @@ pub enum GasPreference {
     Value(BlobGasPrice),
 }
 
+impl std::fmt::Debug for GasPreference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GasPreference::RelativeToHead(_, factor) => write!(f, "RelativeToHead({})", factor),
+            GasPreference::Value(value) => write!(f, "Value({})", value),
+        }
+    }
+}
+
 const FACTOR_RESOLUTION: u128 = 1000;
 
 impl GasPreference {
@@ -161,6 +170,7 @@ impl GasPreference {
     }
 }
 
+#[derive(Debug)]
 pub enum NoncePreference {
     Timebased,
     Value(u64),

--- a/src/data_intent_tracker.rs
+++ b/src/data_intent_tracker.rs
@@ -315,10 +315,9 @@ WHERE data_intents.inclusion_finalized = FALSE;
     .fetch_all(db_pool)
     .await?;
 
-    Ok(rows
-        .iter()
+    rows.iter()
         .map(|row| Ok((Uuid::from_slice(&row.id)?, txhash_from_vec(&row.tx_hash)?)))
-        .collect::<Result<Vec<_>>>()?)
+        .collect::<Result<Vec<_>>>()
 }
 
 pub(crate) async fn mark_data_intents_as_inclusion_finalized(

--- a/src/data_intent_tracker.rs
+++ b/src/data_intent_tracker.rs
@@ -250,6 +250,7 @@ WHERE id = ?
     Ok(row.is_some())
 }
 
+#[allow(dead_code)]
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct IntentInclusion {
     pub tx_hash: TxHash,

--- a/src/eth_provider.rs
+++ b/src/eth_provider.rs
@@ -120,9 +120,7 @@ impl EthProvider {
         }
     }
 
-    pub async fn subscribe_blocks<'a>(
-        &'a self,
-    ) -> Result<SubscribeBlocksFuture<'a>, ProviderError> {
+    pub async fn subscribe_blocks(&self) -> Result<SubscribeBlocksFuture<'_>, ProviderError> {
         match self {
             EthProvider::Http(provider) => {
                 let stream = provider.watch_blocks().await?.stream();

--- a/src/eth_provider.rs
+++ b/src/eth_provider.rs
@@ -76,6 +76,16 @@ impl EthProvider {
         }
     }
 
+    pub async fn get_transaction(
+        &self,
+        tx_hash: TxHash,
+    ) -> Result<Option<Transaction>, ProviderError> {
+        match self {
+            EthProvider::Http(provider) => provider.get_transaction(tx_hash).await,
+            EthProvider::Ws(provider) => provider.get_transaction(tx_hash).await,
+        }
+    }
+
     pub async fn get_block<T: Into<BlockId> + Send + Sync>(
         &self,
         block_hash_or_number: T,

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -8,6 +8,11 @@ const MIN_BLOB_GASPRICE: u128 = 1;
 const BLOB_GASPRICE_UPDATE_FRACTION: u128 = 3338477;
 const TARGET_BLOB_GAS_PER_BLOCK: u128 = 393216;
 
+#[derive(Clone, Copy, Debug, clap::ValueEnum)]
+pub enum FeeEstimator {
+    Default,
+}
+
 #[derive(Debug)]
 pub struct GasConfig {
     pub max_priority_fee_per_gas: u128,
@@ -63,7 +68,7 @@ fn calc_excess_blob_gas(parent_excess_blob_gas: u128, parent_blob_gas_used: u128
 
 /// All transactions in a block must satisfy that
 /// assert tx.max_fee_per_blob_gas >= get_blob_gasprice(block.header)
-pub(crate) fn get_blob_gasprice(excess_blob_gas: u128) -> u128 {
+pub fn get_blob_gasprice(excess_blob_gas: u128) -> u128 {
     fake_exponential(
         MIN_BLOB_GASPRICE,
         excess_blob_gas,
@@ -98,8 +103,6 @@ impl From<BlockWithTxs> for BlockGasSummary {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const TARGET_BLOB_GAS_PER_BLOCK: u128 = 393216;
 
     #[test]
     fn test_calc_excess_blob_gas() {

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -1,6 +1,7 @@
 use ethers::types::{Block, TxHash};
 use eyre::{eyre, Result};
 use serde::{Deserialize, Serialize};
+use std::cmp;
 
 use crate::sync::BlockWithTxs;
 
@@ -13,14 +14,43 @@ pub enum FeeEstimator {
     Default,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct GasConfig {
     pub max_priority_fee_per_gas: u128,
     pub max_fee_per_gas: u128,
     pub max_fee_per_blob_gas: u128,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+impl GasConfig {
+    /// Bump a GasConfig to re-price by at least +110% another gas config from a previous
+    /// transaction.
+    /// Ref: <https://docs.alchemy.com/docs/retrying-an-eip-1559-transaction>
+    pub fn reprice_to_at_least(&mut self, other_gas: GasConfig) {
+        self.max_priority_fee_per_gas = cmp::max(
+            self.max_priority_fee_per_gas,
+            (11 * other_gas.max_priority_fee_per_gas) / 10,
+        );
+        self.max_fee_per_gas = cmp::max(
+            self.max_fee_per_gas, //
+            (11 * other_gas.max_fee_per_gas) / 10,
+        );
+        self.max_fee_per_blob_gas = cmp::max(
+            self.max_fee_per_blob_gas,
+            (11 * other_gas.max_fee_per_blob_gas) / 10,
+        );
+    }
+
+    /// Returns true if this gas config is underpriced against a block gas summary
+    pub fn is_underpriced(&self, block_gas: &BlockGasSummary) -> bool {
+        // TODO: check priority fee too
+        // EVM gas underpriced
+        block_gas.base_fee_per_gas > self.max_fee_per_gas
+        // Blob gas underpriced
+            || block_gas.blob_gas_price() > self.max_fee_per_blob_gas
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub struct BlockGasSummary {
     blob_gas_used: u128,
     excess_blob_gas: u128,

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -131,9 +131,7 @@ pub(crate) fn construct_blob_tx(
             from: wallet.address(),
             nonce: tx_params.nonce,
             used_bytes,
-            max_priority_fee_per_gas: gas_config.max_priority_fee_per_gas,
-            max_fee_per_gas: gas_config.max_fee_per_gas,
-            max_fee_per_blob_gas: gas_config.max_fee_per_blob_gas,
+            gas: *gas_config,
         },
     })
 }

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -123,7 +123,7 @@ pub(crate) fn construct_blob_tx(
 
     Ok(BlobTx {
         blob_tx_payload_body: tx_rlp_with_sig.into(),
-        tx_hash: H256(tx_hash.into()),
+        tx_hash: H256(tx_hash),
         blob_tx_networking: tx_rlp_networking.into(),
         tx_summary: BlobTxSummary {
             participants,
@@ -258,18 +258,7 @@ mod tests {
         );
 
         // Assert gas
-        assert_eq!(
-            blob_tx.tx_summary.max_fee_per_gas,
-            gas_config.max_fee_per_gas
-        );
-        assert_eq!(
-            blob_tx.tx_summary.max_fee_per_blob_gas,
-            gas_config.max_fee_per_blob_gas
-        );
-        assert_eq!(
-            blob_tx.tx_summary.max_priority_fee_per_gas,
-            gas_config.max_priority_fee_per_gas
-        );
+        assert_eq!(blob_tx.tx_summary.gas, gas_config);
 
         // Assert participants
         assert_eq!(blob_tx.tx_summary.participants, participants);

--- a/src/kzg.rs
+++ b/src/kzg.rs
@@ -1,10 +1,11 @@
 use std::cmp::Ordering;
 
-use alloy_primitives::{keccak256, Address, B256, U256};
+use alloy_primitives::{Address, B256, U256};
 use c_kzg::{BYTES_PER_BLOB, FIELD_ELEMENTS_PER_BLOB};
 use ethers::{
     signers::{LocalWallet, Signer},
     types::{Bytes, H256},
+    utils::keccak256,
 };
 use eyre::{bail, Result};
 use reth_primitives::Signature;
@@ -99,28 +100,10 @@ pub(crate) fn construct_blob_tx(
         odd_y_parity: signature.v - 27 != 0,
     };
 
-    // # Calculating the hash
-    //
-    // The full encoding of the `PooledTransaction` response is:
-    // `tx_type (0x03) || rlp([tx_payload_body, blobs, commitments, proofs])`
-    //
-    // The transaction hash however, is:
-    // `keccak256(tx_type (0x03) || rlp(tx_payload_body))`
-    //
-    // Note that this is `tx_payload_body`, not `[tx_payload_body]`, which would be
-    // `[[chain_id, nonce, max_priority_fee_per_gas, ...]]`, i.e. a list within a list.
-    //
-    // Because the pooled transaction encoding is different than the hash encoding for
-    // EIP-4844 transactions, we do not use the original buffer to calculate the hash.
-    //
-    // Instead, we use `encode_with_signature`, which RLP encodes the transaction with a
-    // signature for hashing without a header. We then hash the result.
-    let mut tx_rlp_with_sig = Vec::new();
-    tx.encode_with_signature(&signature, &mut tx_rlp_with_sig, false);
-    let tx_hash = keccak256(&tx_rlp_with_sig);
+    let (tx_hash, tx_rlp_with_sig) = compute_blob_tx_hash(&tx, &signature);
 
     let blob_tx = BlobTransaction {
-        hash: tx_hash,
+        hash: tx_hash.into(),
         transaction: tx,
         signature,
         sidecar: BlobTransactionSidecar {
@@ -153,6 +136,28 @@ pub(crate) fn construct_blob_tx(
             max_fee_per_blob_gas: gas_config.max_fee_per_blob_gas,
         },
     })
+}
+
+// # Calculating the hash
+//
+// The full encoding of the `PooledTransaction` response is:
+// `tx_type (0x03) || rlp([tx_payload_body, blobs, commitments, proofs])`
+//
+// The transaction hash however, is:
+// `keccak256(tx_type (0x03) || rlp(tx_payload_body))`
+//
+// Note that this is `tx_payload_body`, not `[tx_payload_body]`, which would be
+// `[[chain_id, nonce, max_priority_fee_per_gas, ...]]`, i.e. a list within a list.
+//
+// Because the pooled transaction encoding is different than the hash encoding for
+// EIP-4844 transactions, we do not use the original buffer to calculate the hash.
+//
+// Instead, we use `encode_with_signature`, which RLP encodes the transaction with a
+// signature for hashing without a header. We then hash the result.
+pub fn compute_blob_tx_hash(tx: &TxEip4844, signature: &Signature) -> ([u8; 32], Vec<u8>) {
+    let mut tx_rlp_with_sig = Vec::new();
+    tx.encode_with_signature(signature, &mut tx_rlp_with_sig, false);
+    (keccak256(&tx_rlp_with_sig), tx_rlp_with_sig)
 }
 
 // Chunk data in 31 bytes to ensure each field element is < BLS_MODULUS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -244,11 +244,6 @@ impl App {
         );
         // TODO: handle initial sync here with a nice progress bar
 
-        let mut data_intent_tracker = DataIntentTracker::default();
-        info!("syncing data intent track");
-        data_intent_tracker.sync_with_db(&db_pool).await?;
-        info!("synced data intent track");
-
         let config = AppConfig {
             l1_inbox_address: Address::from_str(ADDRESS_ZERO)?,
             panic_on_background_task_errors: args.panic_on_background_task_errors,
@@ -278,7 +273,7 @@ impl App {
             provider,
             wallet,
             chain_id,
-            data_intent_tracker,
+            DataIntentTracker::default(),
             sync,
         ));
 
@@ -294,6 +289,10 @@ impl App {
         if !finalized_ids.is_empty() {
             info!("marked some data intents as finalized {:?}", finalized_ids);
         }
+
+        info!("syncing data intent tracker");
+        app_data.sync_data_intents().await?;
+        info!("synced data intent tracker");
 
         let address = args.address();
         let listener = TcpListener::bind(address.clone())?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,14 +47,14 @@ mod reth_fork;
 mod routes;
 mod sync;
 mod trusted_setup;
-mod utils;
+pub mod utils;
 
 pub use blob_tx_data::BlobTxSummary;
 pub use client::Client;
 pub use data_intent::{BlobGasPrice, DataIntent};
 pub use gas::BlockGasSummary;
+pub use kzg::compute_blob_tx_hash;
 pub use metrics::{PushMetricsConfig, PushMetricsFormat};
-pub use utils::increase_by_min_percent;
 
 // Use log crate when building application
 #[cfg(not(test))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,10 +123,6 @@ pub struct Args {
     #[arg(env, long, default_value_t = 6)]
     pub max_pending_transactions: u64,
 
-    /// Choose strategy to decide eip1559 style fees
-    #[arg(env, long, value_enum, default_value_t = FeeEstimator::Default)]
-    pub fee_estimator: FeeEstimator,
-
     /// Database URL to mysql DB with format `mysql://user:password@localhost/test`
     #[arg(env, long)]
     pub database_url: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,14 @@ impl App {
             &args.eth_provider, chain_id
         );
 
+        info!("running consistency checks");
+        let finalized_ids = app_data
+            .initial_consistency_check_intents_with_inclusion_finalized()
+            .await?;
+        if !finalized_ids.is_empty() {
+            info!("marked some data intents as finalized {:?}", finalized_ids);
+        }
+
         let address = args.address();
         let listener = TcpListener::bind(address.clone())?;
         let listener_port = listener.local_addr().unwrap().port();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,7 +185,12 @@ impl App {
     pub async fn build(args: Args) -> Result<Self> {
         let starting_point = StartingPoint::StartingBlock(args.starting_block);
 
-        let provider = EthProvider::new(&args.eth_provider).await?;
+        let mut provider = EthProvider::new(&args.eth_provider).await?;
+
+        if let Some(eth_provider_interval) = args.eth_provider_interval {
+            provider.set_interval(Duration::from_millis(eth_provider_interval));
+        }
+
         let chain_id = provider.get_chainid().await?.as_u64();
 
         // TODO: read as param

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub mod utils;
 pub use blob_tx_data::BlobTxSummary;
 pub use client::Client;
 pub use data_intent::{BlobGasPrice, DataIntent};
-pub use gas::BlockGasSummary;
+pub use gas::{get_blob_gasprice, BlockGasSummary, FeeEstimator};
 pub use kzg::compute_blob_tx_hash;
 pub use metrics::{PushMetricsConfig, PushMetricsFormat};
 
@@ -122,6 +122,10 @@ pub struct Args {
     /// underpriced in volatile network conditions.
     #[arg(env, long, default_value_t = 6)]
     pub max_pending_transactions: u64,
+
+    /// Choose strategy to decide eip1559 style fees
+    #[arg(env, long, value_enum, default_value_t = FeeEstimator::Default)]
+    pub fee_estimator: FeeEstimator,
 
     /// Database URL to mysql DB with format `mysql://user:password@localhost/test`
     #[arg(env, long)]

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -3,7 +3,7 @@ use std::cmp;
 use crate::utils::increase_by_min_percent;
 
 /// (len, max_len_price)
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 pub struct Item {
     pub len: usize,
     pub max_len_price: u64,

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -1,6 +1,6 @@
 use std::cmp;
 
-use crate::increase_by_min_percent;
+use crate::utils::increase_by_min_percent;
 
 /// (len, max_len_price)
 #[derive(Copy, Clone)]

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -56,7 +56,7 @@ pub(crate) async fn get_sync(
 pub(crate) async fn get_data(
     data: web::Data<Arc<AppData>>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let items: Vec<DataIntentSummary> = data.get_all_pending().await;
+    let items: Vec<DataIntentSummary> = data.get_all_intents_available_for_packing().await;
     Ok(HttpResponse::Ok().json(items))
 }
 
@@ -137,7 +137,7 @@ impl DataIntentStatus {
     pub fn is_in_tx(&self) -> Option<TxHash> {
         match self {
             DataIntentStatus::Unknown | DataIntentStatus::Pending => None,
-            DataIntentStatus::InPendingTx { tx_hash } => Some(*tx_hash),
+            DataIntentStatus::InPendingTx { tx_hash, .. } => Some(*tx_hash),
             DataIntentStatus::InConfirmedTx { tx_hash, .. } => Some(*tx_hash),
         }
     }

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -56,7 +56,10 @@ pub(crate) async fn get_sync(
 pub(crate) async fn get_data(
     data: web::Data<Arc<AppData>>,
 ) -> Result<HttpResponse, actix_web::Error> {
-    let items: Vec<DataIntentSummary> = data.get_all_intents_available_for_packing().await;
+    let items: Vec<DataIntentSummary> = data
+        .get_all_intents_available_for_packing(usize::MAX)
+        .await
+        .0;
     Ok(HttpResponse::Ok().json(items))
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -68,7 +68,7 @@ pub fn vec_to_hex_0x_prefix(v: &[u8]) -> String {
     format!("0x{}", hex::encode(v))
 }
 
-/// Decode 0x prefixed hex encoded string to Vec<u8>
+/// Decode 0x prefixed hex encoded string to `Vec<u8>`
 pub fn hex_0x_prefix_to_vec(hex: &str) -> Result<Vec<u8>> {
     Ok(hex::decode(hex.trim_start_matches("0x"))?)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -82,7 +82,7 @@ pub(crate) fn address_from_vec(v: Vec<u8>) -> Result<Address> {
 }
 
 /// Convert `Vec<u8>` into ethers TxHash H256 type. Errors if v.len() != 32.
-pub(crate) fn txhash_from_vec(v: Vec<u8>) -> Result<TxHash> {
+pub(crate) fn txhash_from_vec(v: &[u8]) -> Result<TxHash> {
     let fixed_vec: [u8; 32] = v
         .try_into()
         .map_err(|_| eyre!("txhash as vec not 32 bytes in len"))?;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -102,15 +102,17 @@ pub fn deserialize_blob_tx_pooled(serialized_networking_blob_tx: &[u8]) -> Resul
 
 /// Convert a reth transaction to ethers
 pub fn tx_reth_to_ethers(txr: &TxEip4844) -> Result<Transaction> {
-    let mut tx = Transaction::default();
-    tx.chain_id = Some(txr.chain_id.into());
-    tx.nonce = txr.nonce.into();
-    tx.gas = txr.gas_limit.into();
-    tx.max_fee_per_gas = Some(txr.max_fee_per_gas.into());
-    tx.max_priority_fee_per_gas = Some(txr.max_priority_fee_per_gas.into());
-    tx.to = Some(H160(txr.to.into()));
-    tx.input = txr.input.to_vec().into();
-    tx.value = serde_json::from_value(serde_json::to_value(txr.value)?)?;
+    let mut tx = Transaction {
+        chain_id: Some(txr.chain_id.into()),
+        nonce: txr.nonce.into(),
+        gas: txr.gas_limit.into(),
+        max_fee_per_gas: Some(txr.max_fee_per_gas.into()),
+        max_priority_fee_per_gas: Some(txr.max_priority_fee_per_gas.into()),
+        to: Some(H160(txr.to.into())),
+        input: txr.input.to_vec().into(),
+        value: serde_json::from_value(serde_json::to_value(txr.value)?)?,
+        ..Default::default()
+    };
     tx.other.insert(
         "maxFeePerBlobGas".to_string(),
         serde_json::to_value(Into::<U256>::into(txr.max_fee_per_blob_gas))?,

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -74,7 +74,7 @@ pub fn hex_0x_prefix_to_vec(hex: &str) -> Result<Vec<u8>> {
 }
 
 /// Convert `Vec<u8>` into ethers Address H160 type. Errors if v.len() != 20.
-pub(crate) fn address_from_vec(v: Vec<u8>) -> Result<Address> {
+pub(crate) fn address_from_vec(v: &[u8]) -> Result<Address> {
     let fixed_vec: [u8; 20] = v
         .try_into()
         .map_err(|_| eyre!("address as vec not 20 bytes in len"))?;
@@ -82,7 +82,7 @@ pub(crate) fn address_from_vec(v: Vec<u8>) -> Result<Address> {
 }
 
 /// Convert `Vec<u8>` into ethers TxHash H256 type. Errors if v.len() != 32.
-pub(crate) fn txhash_from_vec(v: &[u8]) -> Result<TxHash> {
+pub fn txhash_from_vec(v: &[u8]) -> Result<TxHash> {
     let fixed_vec: [u8; 32] = v
         .try_into()
         .map_err(|_| eyre!("txhash as vec not 32 bytes in len"))?;

--- a/tests/api/geth_test.rs
+++ b/tests/api/geth_test.rs
@@ -2,13 +2,12 @@ use std::{str::FromStr, time::Duration};
 
 use crate::{
     geth_helpers::GethMode,
+    helpers::get_signer_genesis_funds,
     run_lodestar::{spawn_lodestar, RunLodestarArgs},
     spawn_geth,
 };
-use ethers::{
-    providers::Middleware,
-    types::{Address, TransactionRequest},
-};
+use ethers::providers::Middleware;
+use ethers::types::{Address, TransactionRequest};
 use eyre::Result;
 use tokio::time::timeout;
 
@@ -25,7 +24,7 @@ async fn geth_test_spawn_interop() {
 #[tokio::test]
 async fn geth_send_regular_transaction_no_inclusion() -> Result<()> {
     let geth = spawn_geth(GethMode::Interop).await;
-    let client = geth.http_provider().unwrap();
+    let client = get_signer_genesis_funds(geth.http_url(), geth.get_chain_id()).unwrap();
 
     let from = client.address();
     let to = Address::from_str("0x0000000000000000000000000000000000000000").unwrap();
@@ -54,7 +53,7 @@ async fn geth_send_regular_transaction_with_inclusion() -> Result<()> {
     })
     .await;
 
-    let client = geth.http_provider().unwrap();
+    let client = get_signer_genesis_funds(geth.http_url(), geth.get_chain_id()).unwrap();
 
     let from = client.address();
     let to = Address::from_str("0x0000000000000000000000000000000000000000").unwrap();

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -1,11 +1,13 @@
 use ethers::{
+    middleware::SignerMiddleware,
     providers::{Http, Middleware, Provider},
-    signers::LocalWallet,
+    signers::{LocalWallet, Signer},
     types::{Address, Block, Transaction, TransactionRequest, TxHash, H256, U256},
     utils::parse_ether,
 };
 use eyre::{bail, eyre, Result};
 use futures::future::try_join_all;
+use lazy_static::lazy_static;
 use log::LevelFilter;
 use rand::{distributions::Alphanumeric, Rng};
 use sqlx::{Connection, Executor, MySqlConnection, MySqlPool};
@@ -14,6 +16,7 @@ use std::{
     future::Future,
     hash::Hash,
     mem,
+    str::FromStr,
     time::{Duration, Instant},
 };
 use tempfile::{tempdir, TempDir};
@@ -27,7 +30,8 @@ use blob_share::{
 };
 
 use crate::{
-    geth_helpers::{GethMode, WalletWithProvider},
+    geth_helpers::GethMode,
+    mock_el_server::MockEthereumServer,
     run_lodestar::{spawn_lodestar, LodestarInstance, RunLodestarArgs},
     spawn_geth, GethInstance,
 };
@@ -36,12 +40,19 @@ use crate::{
 pub const FINALIZE_DEPTH: u64 = 8;
 pub const ONE_HUNDRED_MS: Duration = Duration::from_millis(100);
 
+const DEV_PRIVKEY: &str = "392a230386a19b84b6b865067d5493b158e987d28104ab16365854a8fd851bb0";
+const DEV_PUBKEY: &str = "0xdbD48e742FF3Ecd3Cb2D557956f541b6669b3277";
+
+lazy_static! {
+    pub static ref GENESIS_FUNDS_ADDR: Address = Address::from_str(DEV_PUBKEY).unwrap();
+}
+
 #[allow(dead_code)]
 pub struct TestHarness {
     pub client: Client,
     base_url: String,
-    pub eth_provider: Provider<Http>,
-    geth_instance: GethInstance,
+    mock_ethereum_server: Option<MockEthereumServer>,
+    geth_instance: Option<GethInstance>,
     lodestar_instance: Option<LodestarInstance>,
     pub temp_data_dir: TempDir,
     pub sender_address: Address,
@@ -49,8 +60,9 @@ pub struct TestHarness {
 }
 
 pub enum TestMode {
+    ELMock,
     ELOnly,
-    WithChain,
+    ELAndCL,
 }
 
 pub enum AppStatus {
@@ -85,7 +97,7 @@ impl TestHarness {
 
     #[allow(dead_code)]
     pub async fn spawn_with_chain() -> Self {
-        TestHarness::build(TestMode::WithChain, None)
+        TestHarness::build(TestMode::ELAndCL, None)
             .await
             .spawn_app_in_background()
     }
@@ -104,24 +116,33 @@ impl TestHarness {
             .is_test(true)
             .try_init();
 
-        let (geth_instance, lodestar_instance) = match test_mode {
+        let (geth_instance, lodestar_instance, mock_ethereum_server) = match test_mode {
+            TestMode::ELMock => (
+                None,
+                None,
+                Some(
+                    MockEthereumServer::build()
+                        .await
+                        .spawn_app_in_background()
+                        .with_genesis_block(),
+                ),
+            ),
             TestMode::ELOnly => {
                 let geth = spawn_geth(GethMode::Dev).await;
-                (geth, None)
+                (Some(geth), None, None)
             }
-            TestMode::WithChain => {
+            TestMode::ELAndCL => {
                 let geth = spawn_geth(GethMode::Interop).await;
                 let lodestar = spawn_lodestar(RunLodestarArgs {
                     execution_url: geth.authrpc_url(),
                     genesis_eth1_hash: geth.genesis_block_hash_hex(),
                 })
                 .await;
-                (geth, Some(lodestar))
+                (Some(geth), Some(lodestar), None)
             }
         };
 
-        let eth_provider = Provider::<Http>::try_from(geth_instance.http_url()).unwrap();
-        let eth_provider = eth_provider.interval(Duration::from_millis(50));
+        let eth_provider_urls = get_eth_provider_urls(&geth_instance, &mock_ethereum_server);
 
         // Randomise configuration to ensure test isolation
         let database_name = random_alphabetic_string(16);
@@ -132,7 +153,8 @@ impl TestHarness {
 
         // Apply test config to anchor block
         if let Some(test_config) = test_config {
-            let provider = EthProvider::Http(eth_provider.clone());
+            let provider = Provider::<Http>::try_from(&eth_provider_urls.http).unwrap();
+            let provider = EthProvider::Http(provider.clone());
             let mut anchor_block = anchor_block_from_starting_block(&provider, 0)
                 .await
                 .unwrap();
@@ -153,7 +175,8 @@ impl TestHarness {
         let args = Args {
             port: 0,
             bind_address: "127.0.0.1".to_string(),
-            eth_provider: geth_instance.ws_url().to_string(),
+            // Use websockets when using actual Geth to test that path
+            eth_provider: eth_provider_urls.ws.unwrap_or(eth_provider_urls.http),
             // Set polling interval to 1 milisecond since anvil auto-mines on each transaction
             eth_provider_interval: Some(1),
             starting_block: 0,
@@ -186,7 +209,7 @@ impl TestHarness {
         Self {
             client,
             base_url,
-            eth_provider,
+            mock_ethereum_server,
             geth_instance,
             lodestar_instance,
             temp_data_dir,
@@ -234,6 +257,22 @@ impl TestHarness {
         }
     }
 
+    pub fn eth_provider_http(&self) -> Provider<Http> {
+        Provider::<Http>::try_from(self.eth_provider_urls().http)
+            .unwrap()
+            .interval(Duration::from_millis(50))
+    }
+
+    pub fn geth(&self) -> &GethInstance {
+        self.geth_instance
+            .as_ref()
+            .expect("not using geth instance")
+    }
+
+    fn eth_provider_urls(&self) -> EthProviderURLs {
+        get_eth_provider_urls(&self.geth_instance, &self.mock_ethereum_server)
+    }
+
     pub fn get_blob_consumer(&self, participant_address: Address) -> BlobConsumer {
         let beacon_api_base_url = match &self.lodestar_instance {
             Some(lodestar_instance) => lodestar_instance.http_url(),
@@ -242,7 +281,7 @@ impl TestHarness {
 
         BlobConsumer::new(
             beacon_api_base_url,
-            self.geth_instance.http_url(),
+            &self.eth_provider_urls().http,
             self.sender_address,
             participant_address,
         )
@@ -259,7 +298,7 @@ impl TestHarness {
             .post_data_with_wallet(
                 wallet,
                 vec![0xff; data_len],
-                &GasPreference::RelativeToHead(EthProvider::Http(self.eth_provider.clone()), 1.0),
+                &GasPreference::RelativeToHead(EthProvider::Http(self.eth_provider_http()), 1.0),
                 &NoncePreference::Timebased,
             )
             .await
@@ -277,7 +316,7 @@ impl TestHarness {
             .post_data_with_wallet(
                 wallet,
                 data,
-                &GasPreference::RelativeToHead(EthProvider::Http(self.eth_provider.clone()), 1.0),
+                &GasPreference::RelativeToHead(EthProvider::Http(self.eth_provider_http()), 1.0),
                 &nonce.unwrap_or(NoncePreference::Timebased),
             )
             .await
@@ -304,6 +343,8 @@ impl TestHarness {
         expected_tx_hash: Option<H256>,
         timeout: Duration,
     ) -> Result<(H256, H256)> {
+        let eth_provider = self.eth_provider_http();
+
         match retry_with_timeout(
             || async {
                 let status = self.client.get_status_by_id(*id).await?;
@@ -318,8 +359,7 @@ impl TestHarness {
         {
             Ok(result) => Ok(result),
             Err(e) => {
-                let sender_nonce = self
-                    .eth_provider
+                let sender_nonce = eth_provider
                     .get_transaction_count(self.sender_address, None)
                     .await?
                     .as_usize();
@@ -427,11 +467,11 @@ impl TestHarness {
     }
 
     pub async fn get_all_past_sender_txs(&self) -> Result<Vec<Transaction>> {
+        let eth_provider = self.eth_provider_http();
         let mut txs = vec![];
-        let head_number = self.eth_provider.get_block_number().await?.as_u64();
+        let head_number = eth_provider.get_block_number().await?.as_u64();
         for block_number in (1..=head_number).rev() {
-            let block = self
-                .eth_provider
+            let block = eth_provider
                 .get_block_with_txs(block_number)
                 .await?
                 .expect(&format!("no block at number {block_number}"));
@@ -463,8 +503,62 @@ impl TestHarness {
     }
 
     pub fn get_signer_genesis_funds(&self) -> WalletWithProvider {
-        self.geth_instance.http_provider().unwrap()
+        get_signer_genesis_funds(&self.eth_provider_urls().http, self.chain_id()).unwrap()
     }
+
+    pub fn chain_id(&self) -> u64 {
+        if let Some(mock_el) = &self.mock_ethereum_server {
+            mock_el.get_chain_id()
+        } else if let Some(geth) = &self.geth_instance {
+            geth.get_chain_id()
+        } else {
+            unreachable!("no EL")
+        }
+    }
+}
+
+struct EthProviderURLs {
+    http: String,
+    ws: Option<String>,
+}
+
+fn get_eth_provider_urls(
+    geth_instance: &Option<GethInstance>,
+    mock_el: &Option<MockEthereumServer>,
+) -> EthProviderURLs {
+    if let Some(mock_el) = &mock_el {
+        EthProviderURLs {
+            http: mock_el.http_url(),
+            ws: None,
+        }
+    } else if let Some(geth_instance) = &geth_instance {
+        EthProviderURLs {
+            http: geth_instance.http_url().to_string(),
+            ws: Some(geth_instance.ws_url().to_string()),
+        }
+    } else {
+        unreachable!("no EL")
+    }
+}
+
+pub type WalletWithProvider = SignerMiddleware<Provider<Http>, LocalWallet>;
+
+pub fn get_wallet_genesis_funds() -> LocalWallet {
+    LocalWallet::from_bytes(&hex::decode(DEV_PRIVKEY).unwrap()).unwrap()
+}
+
+pub fn get_signer_genesis_funds(
+    eth_provider_url: &str,
+    chain_id: u64,
+) -> Result<WalletWithProvider> {
+    let wallet = get_wallet_genesis_funds();
+    assert_eq!(wallet.address(), *GENESIS_FUNDS_ADDR);
+    let provider = Provider::<Http>::try_from(eth_provider_url)?;
+
+    Ok(SignerMiddleware::new(
+        provider,
+        wallet.with_chain_id(chain_id),
+    ))
 }
 
 async fn connect_db_pool(database_url: &str) -> MySqlPool {

--- a/tests/api/helpers.rs
+++ b/tests/api/helpers.rs
@@ -190,7 +190,6 @@ impl TestHarness {
             panic_on_background_task_errors: true,
             finalize_depth: FINALIZE_DEPTH,
             max_pending_transactions: 6,
-            fee_estimator: blob_share::FeeEstimator::Default,
             // TODO: De-duplicate of configure properly
             database_url: format!("{database_url_without_db}/{database_name}"),
             metrics: false,

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -1,6 +1,7 @@
 mod geth_helpers;
 mod geth_test;
 mod helpers;
+mod mock_el_server;
 mod post_intents;
 mod run_lodestar;
 

--- a/tests/api/main.rs
+++ b/tests/api/main.rs
@@ -4,5 +4,6 @@ mod helpers;
 mod mock_el_server;
 mod post_intents;
 mod run_lodestar;
+mod tx_reorg;
 
 pub use geth_helpers::{spawn_geth, GethInstance};

--- a/tests/api/mock_el.rs
+++ b/tests/api/mock_el.rs
@@ -1,1 +1,0 @@
-pub struct 

--- a/tests/api/mock_el_server.rs
+++ b/tests/api/mock_el_server.rs
@@ -1,0 +1,224 @@
+use actix_web::dev::Server;
+use actix_web::{web, App, HttpResponse, HttpServer};
+use ethers::providers::{Http, Provider};
+use ethers::types::{Block, Transaction, H256};
+use eyre::{bail, eyre, Result};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::mem;
+use std::net::TcpListener;
+use std::sync::{Arc, Mutex};
+
+// Define your JSON RPC request and response structures as before
+
+// Mock Ethereum Server Struct
+pub struct MockEthereumServer {
+    server: ServerStatus,
+    port: u16,
+    data: Arc<Mutex<ServerData>>,
+}
+
+enum ServerStatus {
+    Built(Server),
+    Running,
+}
+
+#[derive(Default)]
+struct ServerData {
+    head_number: u64,
+    blocks_by_hash: HashMap<String, Block<Transaction>>,
+    blocks_by_number: HashMap<u64, Block<Transaction>>,
+    next_filter_id: usize,
+    chain_id: u64,
+}
+
+impl MockEthereumServer {
+    // Function to start the server
+    pub async fn build() -> Self {
+        // Find a random available port
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        let data = Arc::new(Mutex::new(ServerData {
+            head_number: 0,
+            blocks_by_hash: <_>::default(),
+            blocks_by_number: <_>::default(),
+            next_filter_id: 0,
+            chain_id: 69420,
+        }));
+        let data_clone = data.clone();
+
+        let server = HttpServer::new(move || {
+            App::new()
+                .app_data(web::Data::new(data_clone.clone()))
+                .route("/", web::post().to(post_root))
+        })
+        .listen(listener)
+        .unwrap()
+        .run();
+
+        MockEthereumServer {
+            server: ServerStatus::Built(server),
+            port,
+            data,
+        }
+    }
+
+    pub fn spawn_app_in_background(mut self) -> Self {
+        match mem::replace(&mut self.server, ServerStatus::Running) {
+            ServerStatus::Running => panic!("already running"),
+            ServerStatus::Built(app) => {
+                // Run app server in the background
+                let _ = tokio::spawn(app);
+            }
+        }
+        self
+    }
+
+    pub fn with_genesis_block(self) -> Self {
+        let block = get_block_with_txs(0, H256([0xab; 32]));
+        self.add_block(block);
+        self
+    }
+
+    pub fn http_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+
+    pub fn get_ethers_provider(&self) -> Provider<Http> {
+        Provider::<Http>::try_from(self.http_url()).unwrap()
+    }
+
+    pub fn get_chain_id(&self) -> u64 {
+        self.data.lock().unwrap().chain_id
+    }
+
+    pub fn add_block(&self, block: Block<Transaction>) {
+        let mut data = self.data.lock().unwrap();
+        data.blocks_by_hash
+            .insert(tx_hash_to_hex(block.hash.unwrap()), block.clone());
+        data.blocks_by_number
+            .insert(block.number.unwrap().as_u64(), block);
+    }
+}
+
+fn tx_hash_to_hex(tx_hash: H256) -> String {
+    format!("0x{}", hex::encode(tx_hash.to_fixed_bytes()))
+}
+
+// Define a structure for the JSON RPC request
+#[derive(Deserialize)]
+struct JsonRpcRequest {
+    method: String,
+    params: Option<serde_json::Value>,
+    id: u64,
+}
+
+impl JsonRpcRequest {
+    fn get_param<T: DeserializeOwned>(&self, i: usize) -> Result<T> {
+        let param_value = self
+            .params
+            .as_ref()
+            .ok_or_else(|| eyre!("no params field"))?
+            .get(i)
+            .ok_or_else(|| eyre!("missing param[{i}]"))?
+            .clone();
+        Ok(serde_json::from_value(param_value)?)
+    }
+
+    fn get_param_hex_u64(&self, i: usize) -> Result<u64> {
+        let hex_str: String = self.get_param(i)?;
+        let hex_str = hex_str.trim_start_matches("0x");
+        Ok(u64::from_str_radix(hex_str, 16)?)
+    }
+}
+
+fn value_to_hex(v: u64) -> String {
+    format!("0x{:x}", v)
+}
+
+// Define a structure for the JSON RPC response
+#[derive(Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: String,
+    result: serde_json::Value,
+    id: u64,
+}
+
+fn handle_ethereum_rpc(data: &mut ServerData, req: &JsonRpcRequest) -> Result<serde_json::Value> {
+    Ok(match req.method.as_str() {
+        "eth_chainId" => serde_json::to_value(value_to_hex(data.chain_id))?,
+
+        "eth_blockNumber" => serde_json::to_value(value_to_hex(data.head_number))?,
+
+        "eth_getBlockByHash" => {
+            let hash: String = req.get_param(0)?;
+            let block = data
+                .blocks_by_hash
+                .get(&hash)
+                .ok_or_else(|| eyre!(format!("unknown block {hash}")))?;
+            serde_json::to_value(block)?
+        }
+
+        "eth_getBlockByNumber" => {
+            let number = req.get_param_hex_u64(0)?;
+            let block = data
+                .blocks_by_number
+                .get(&number)
+                .ok_or_else(|| eyre!(format!("unknown block {number}")))?;
+            serde_json::to_value(block)?
+        }
+
+        "eth_newBlockFilter" => {
+            let id = data.next_filter_id;
+            data.next_filter_id = id + 1;
+            serde_json::to_value(value_to_hex(id as u64))?
+        }
+
+        _ => bail!("unknown route {}", req.method.as_str()),
+    })
+}
+
+async fn post_root(
+    data: web::Data<Arc<Mutex<ServerData>>>,
+    req: web::Json<JsonRpcRequest>,
+) -> Result<HttpResponse, actix_web::Error> {
+    Ok(HttpResponse::Ok().json(JsonRpcResponse {
+        jsonrpc: "2.0".to_string(),
+        result: handle_ethereum_rpc(&mut data.lock().unwrap(), &req)
+            .map_err(actix_web::error::ErrorInternalServerError)?,
+        id: req.id,
+    }))
+}
+
+pub fn get_block_with_txs(number: u64, hash: H256) -> Block<Transaction> {
+    let mut block = Block::<Transaction>::default();
+    block.number = Some(number.into());
+    block.hash = Some(hash);
+    block.base_fee_per_gas = Some(0.into());
+    block.blob_gas_used = Some(0.into());
+    block.excess_blob_gas = Some(0.into());
+    block
+}
+
+#[cfg(test)]
+mod tests {
+    use ethers::providers::Middleware;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn retrieve_block_from_mock() {
+        let mock_server = MockEthereumServer::build().await.spawn_app_in_background();
+        let provider = mock_server.get_ethers_provider();
+
+        let number = 123;
+        let hash = H256([0xaa; 32]);
+        let block = get_block_with_txs(number, hash);
+        mock_server.add_block(block);
+
+        provider.get_block_with_txs(number).await.unwrap();
+        provider.get_block_with_txs(hash).await.unwrap();
+    }
+}

--- a/tests/api/post_intents.rs
+++ b/tests/api/post_intents.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
 use crate::helpers::{
-    retry_with_timeout, unique, Config, TestHarness, TestMode, FINALIZE_DEPTH, GENESIS_FUNDS_ADDR,
+    retry_with_timeout, unique, Config, DataReq, TestHarness, TestMode, FINALIZE_DEPTH,
+    GENESIS_FUNDS_ADDR,
 };
 use blob_share::{
-    client::{NoncePreference, PostDataIntentV1, PostDataIntentV1Signed},
+    client::{PostDataIntentV1, PostDataIntentV1Signed},
     MAX_PENDING_DATA_LEN_PER_USER, MAX_USABLE_BLOB_DATA_LEN,
 };
 use ethers::signers::{LocalWallet, Signer};
@@ -23,15 +24,14 @@ async fn reject_post_data_before_any_topup() {
         .spawn_with_fn(|test_harness| async move {
             let wallet = test_harness.get_signer_genesis_funds();
             // Send data request before funding the sender address
-            let res = test_harness.post_data_of_len(&wallet.signer(), 69).await;
+            let res = test_harness.post_data(&wallet.signer(), DataReq::new().with_data_len(69)).await;
 
             assert_eq!(
                 res.unwrap_err().to_string(),
                 "non-success response status 400 body: Insufficient balance 0 for intent with cost 69"
             );
         })
-        .await
-        .unwrap();
+        .await;
 }
 
 #[tokio::test]
@@ -46,19 +46,19 @@ async fn reject_post_data_after_insufficient_balance() {
 
         // First request should be ok
         test_harness
-            .post_data_of_len(wallet.signer(), 1000)
-            .await
-            .unwrap();
+            .post_data_ok(wallet.signer(), DataReq::new().with_data_len(1000))
+            .await;
         // Second request must be rejected
-        let res = test_harness.post_data_of_len(wallet.signer(), 1000).await;
+        let res = test_harness
+            .post_data(wallet.signer(), DataReq::new().with_data_len(1000))
+            .await;
 
         assert_eq!(
             res.unwrap_err().to_string(),
             "non-success response status 400 body: Insufficient balance 0 for intent with cost 1000"
         );
     })
-    .await
-    .unwrap();
+    .await;
 }
 
 #[tokio::test]
@@ -72,7 +72,7 @@ async fn reject_single_data_intent_too_big() {
         let wallet = test_harness.get_signer_genesis_funds();
         // Send data request before funding the sender address
         let res = test_harness
-            .post_data_of_len(&wallet.signer(), MAX_USABLE_BLOB_DATA_LEN + 1)
+            .post_data(&wallet.signer(), DataReq::new().with_data_len( MAX_USABLE_BLOB_DATA_LEN + 1))
             .await;
 
         assert_eq!(
@@ -80,8 +80,7 @@ async fn reject_single_data_intent_too_big() {
             "non-success response status 400 body: data length 126977 over max usable blob data 126976"
         );
     })
-    .await
-    .unwrap();
+    .await;
 }
 
 // Without sending transactions all pending data intents are not included in any transaction
@@ -113,22 +112,26 @@ async fn reject_posting_too_many_pending_intents(send_blob_txs: bool) {
 
         for _ in 0..MAX_PENDING_DATA_LEN_PER_USER / MAX_USABLE_BLOB_DATA_LEN {
             test_harness
-                .post_data_of_len(&wallet.signer(), MAX_USABLE_BLOB_DATA_LEN)
-                .await
-                .unwrap();
+                .post_data_ok(
+                    &wallet.signer(),
+                    DataReq::new().with_data_len(MAX_USABLE_BLOB_DATA_LEN),
+                )
+                .await;
         }
 
         // Send data request before funding the sender address
         let res = test_harness
-            .post_data_of_len(&wallet.signer(), MAX_USABLE_BLOB_DATA_LEN)
+            .post_data(
+                &wallet.signer(),
+                DataReq::new().with_data_len(MAX_USABLE_BLOB_DATA_LEN),
+            )
             .await;
         assert_eq!(
             res.unwrap_err().to_string(),
             "non-success response status 400 body: pending total data_len 2158592 over max 2031616"
         );
     })
-    .await
-    .unwrap();
+    .await;
 }
 
 #[tokio::test]
@@ -191,8 +194,7 @@ where
             err_str
         );
     })
-    .await
-    .unwrap();
+    .await;
 }
 
 #[tokio::test]
@@ -211,8 +213,7 @@ async fn post_two_intents_and_expect_blob_tx() {
                 test_post_two_data_intents_up_to_inclusion(&test_harness, wallet.signer(), 0).await;
             }
         })
-        .await
-        .unwrap();
+        .await;
 }
 
 #[tokio::test]
@@ -241,8 +242,7 @@ async fn post_many_intents_series_and_expect_blob_tx() {
                 }
             }
         })
-        .await
-        .unwrap();
+        .await;
 }
 
 async fn test_post_two_data_intents_up_to_inclusion(
@@ -270,7 +270,7 @@ async fn test_post_two_data_intents_up_to_inclusion(
         .unwrap();
 
     let intent_1_id = test_harness
-        .post_data_and_wait_for_pending(wallet, data_1.clone())
+        .post_data_and_wait_for_pending(wallet, DataReq::new().with_data(data_1.clone()))
         .await;
 
     // Check data intent is stored
@@ -295,13 +295,12 @@ async fn test_post_two_data_intents_up_to_inclusion(
     );
 
     let intent_2_id = test_harness
-        .post_data_and_wait_for_pending(wallet, data_2.clone())
+        .post_data_and_wait_for_pending(wallet, DataReq::new().with_data(data_2.clone()))
         .await;
 
     let intents_txhash = test_harness
         .wait_for_intent_inclusion_in_any_tx(&[intent_1_id, intent_2_id], Duration::from_secs(1))
-        .await
-        .unwrap();
+        .await;
     assert_eq!(
         intents_txhash[0], intents_txhash[1],
         "two intents should be in the same tx"
@@ -387,10 +386,9 @@ async fn post_many_intents_parallel_and_expect_blob_tx() {
                     info!("sending data intent with nonce {}", i);
                     intent_ids.push(
                         test_harness
-                            .post_data(
+                            .post_data_ok(
                                 &wallet.signer(),
-                                data.to_vec(),
-                                Some(NoncePreference::Value(i as u64)),
+                                DataReq::new().with_data(data.to_vec()).with_nonce(i as u64),
                             )
                             .await,
                     )
@@ -409,8 +407,7 @@ async fn post_many_intents_parallel_and_expect_blob_tx() {
                         &intent_ids,
                         Duration::from_millis(200 * N),
                     )
-                    .await
-                    .unwrap();
+                    .await;
                 let unique_intents_txhash = unique(&intents_txhash);
                 if unique_intents_txhash.len() as u64 != N / 2 {
                     panic!(
@@ -445,6 +442,5 @@ async fn post_many_intents_parallel_and_expect_blob_tx() {
                 );
             }
         })
-        .await
-        .unwrap();
+        .await;
 }

--- a/tests/api/post_intents.rs
+++ b/tests/api/post_intents.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
-use crate::{
-    geth_helpers::GENESIS_FUNDS_ADDR,
-    helpers::{retry_with_timeout, unique, Config, TestHarness, TestMode, FINALIZE_DEPTH},
+use crate::helpers::{
+    retry_with_timeout, unique, Config, TestHarness, TestMode, FINALIZE_DEPTH, GENESIS_FUNDS_ADDR,
 };
 use blob_share::{
     client::{NoncePreference, PostDataIntentV1, PostDataIntentV1Signed},
@@ -19,7 +18,7 @@ async fn health_check_works() {
 
 #[tokio::test]
 async fn reject_post_data_before_any_topup() {
-    TestHarness::build(TestMode::ELOnly, None)
+    TestHarness::build(TestMode::ELMock, None)
         .await
         .spawn_with_fn(|test_harness| async move {
             let wallet = test_harness.get_signer_genesis_funds();
@@ -198,7 +197,7 @@ where
 
 #[tokio::test]
 async fn post_two_intents_and_expect_blob_tx() {
-    TestHarness::build(TestMode::WithChain, None)
+    TestHarness::build(TestMode::ELAndCL, None)
         .await
         .spawn_with_fn(|test_harness| {
             async move {
@@ -218,7 +217,7 @@ async fn post_two_intents_and_expect_blob_tx() {
 
 #[tokio::test]
 async fn post_many_intents_series_and_expect_blob_tx() {
-    TestHarness::build(TestMode::WithChain, None)
+    TestHarness::build(TestMode::ELAndCL, None)
         .await
         .spawn_with_fn(|test_harness| {
             async move {
@@ -363,7 +362,7 @@ async fn test_post_two_data_intents_up_to_inclusion(
 
 #[tokio::test]
 async fn post_many_intents_parallel_and_expect_blob_tx() {
-    TestHarness::build(TestMode::WithChain, None)
+    TestHarness::build(TestMode::ELAndCL, None)
         .await
         .spawn_with_fn(|test_harness| {
             async move {

--- a/tests/api/tx_reorg.rs
+++ b/tests/api/tx_reorg.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+
+use blob_share::utils::get_max_fee_per_blob_gas;
+
+use crate::helpers::{
+    Config, DataReq, TestHarness, TestMode, ETH_TO_WEI, GENESIS_FUNDS_ADDR, GWEI_TO_WEI,
+};
+
+#[tokio::test]
+async fn reprice_single_transaction_after_gas_spike() {
+    TestHarness::build(
+        TestMode::ELMock,
+        Some(Config::default().add_initial_topup(*GENESIS_FUNDS_ADDR, ETH_TO_WEI.into())),
+    )
+    .await
+    .spawn_with_fn(|test_harness| {
+        async move {
+            const INITIAL_GAS: u64 = 1 * GWEI_TO_WEI;
+            const HIGHER_GAS: u64 = (1.25 * GWEI_TO_WEI as f64) as u64;
+
+            // Set current gas price at 1 GWei
+            test_harness
+                .mock_el()
+                .mine_block_with(|b| b.base_fee_per_gas = Some(INITIAL_GAS.into()));
+
+            // Send intents priced at 1.25 GWei
+            let wallet = test_harness.get_signer_genesis_funds();
+            let data_intent_id = test_harness
+                .post_data_ok(
+                    &wallet.signer(),
+                    DataReq::new().with_max_blob_gas(HIGHER_GAS),
+                )
+                .await;
+            let tx_hash_first = test_harness
+                .wait_for_intent_inclusion_in_any_tx(&[data_intent_id], Duration::from_secs(1))
+                .await[0];
+
+            // Expect blob tx priced at 1 GWei
+            let tx_first = test_harness.mock_el().get_submitted_tx(tx_hash_first);
+            assert_eq!(
+                get_max_fee_per_blob_gas(&tx_first).unwrap() as u64,
+                1 * GWEI_TO_WEI
+            );
+
+            // Do not include and bump gas to 1.25 GWei
+            test_harness
+                .mock_el()
+                .mine_block_with(|b| b.base_fee_per_gas = Some(HIGHER_GAS.into()));
+
+            // Expect new transaction with same nonce at 1.25 Gwei
+            let tx_hash_repriced = test_harness
+                .wait_for_intent_inclusion_in_any_tx_with_filter(
+                    &[data_intent_id],
+                    Duration::from_secs(1),
+                    &Some(vec![tx_hash_first]),
+                )
+                .await[0];
+
+            // Assert transaction has been correctly repriced (same nonce) and includes the original intents
+            let tx_repriced = test_harness.mock_el().get_submitted_tx(tx_hash_repriced);
+            // TODO: check:
+            // assert!(tx_repriced.ids() == data_intent_ids);
+            assert_eq!(
+                get_max_fee_per_blob_gas(&tx_repriced).unwrap() as u64,
+                HIGHER_GAS
+            );
+            assert!(tx_repriced.nonce == tx_first.nonce);
+        }
+    })
+    .await;
+}

--- a/tests/api/tx_reorg.rs
+++ b/tests/api/tx_reorg.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use blob_share::utils::get_max_fee_per_blob_gas;
 
 use crate::helpers::{
-    Config, DataReq, TestHarness, TestMode, ETH_TO_WEI, GENESIS_FUNDS_ADDR, GWEI_TO_WEI,
+    find_excess_blob_gas, Config, DataReq, TestHarness, TestMode, ETH_TO_WEI, GENESIS_FUNDS_ADDR,
+    GWEI_TO_WEI,
 };
 
 #[tokio::test]
@@ -15,20 +16,24 @@ async fn reprice_single_transaction_after_gas_spike() {
     .await
     .spawn_with_fn(|test_harness| {
         async move {
-            const INITIAL_GAS: u64 = 1 * GWEI_TO_WEI;
-            const HIGHER_GAS: u64 = (1.25 * GWEI_TO_WEI as f64) as u64;
+            const INITIAL_GAS: u64 = 30 * GWEI_TO_WEI;
+            const INITIAL_BLOB_GAS: u64 = 1 * GWEI_TO_WEI;
+            const HIGHER_BLOB_GAS: u64 = (1.25 * GWEI_TO_WEI as f64) as u64;
 
             // Set current gas price at 1 GWei
             test_harness
-                .mock_el()
-                .mine_block_with(|b| b.base_fee_per_gas = Some(INITIAL_GAS.into()));
+                .mine_block_and_wait_for_sync(|b| {
+                    b.base_fee_per_gas = Some(INITIAL_GAS.into());
+                    b.excess_blob_gas = Some(find_excess_blob_gas(INITIAL_BLOB_GAS as u128).into());
+                })
+                .await;
 
             // Send intents priced at 1.25 GWei
             let wallet = test_harness.get_signer_genesis_funds();
             let data_intent_id = test_harness
                 .post_data_ok(
                     &wallet.signer(),
-                    DataReq::new().with_max_blob_gas(HIGHER_GAS),
+                    DataReq::new().with_max_blob_gas(HIGHER_BLOB_GAS),
                 )
                 .await;
             let tx_hash_first = test_harness
@@ -44,8 +49,11 @@ async fn reprice_single_transaction_after_gas_spike() {
 
             // Do not include and bump gas to 1.25 GWei
             test_harness
-                .mock_el()
-                .mine_block_with(|b| b.base_fee_per_gas = Some(HIGHER_GAS.into()));
+                .mine_block_and_wait_for_sync(|b| {
+                    b.base_fee_per_gas = Some(INITIAL_GAS.into());
+                    b.excess_blob_gas = Some(find_excess_blob_gas(HIGHER_BLOB_GAS as u128).into());
+                })
+                .await;
 
             // Expect new transaction with same nonce at 1.25 Gwei
             let tx_hash_repriced = test_harness
@@ -62,7 +70,7 @@ async fn reprice_single_transaction_after_gas_spike() {
             // assert!(tx_repriced.ids() == data_intent_ids);
             assert_eq!(
                 get_max_fee_per_blob_gas(&tx_repriced).unwrap() as u64,
-                HIGHER_GAS
+                HIGHER_BLOB_GAS
             );
             assert!(tx_repriced.nonce == tx_first.nonce);
         }


### PR DESCRIPTION
Adds new test

https://github.com/dapplion/blob_share/blob/f8a18b8ff1428a852218a55fba4fda25ff1354bc/tests/api/tx_reorg.rs#L12

- Set current gas price at 1 GWei
- Send intents priced at 1.25 GWei
- Expect blob tx priced at 1 GWei
- Do not include and bump base fee gas to 1.25 GWei
- Expect new transaction with same nonce at 1.25 Gwei
- Assert transaction has been correctly repriced (same nonce) and includes the original intents